### PR TITLE
Odometry readjustement

### DIFF
--- a/src/assurancetourix/assurancetourix/include/assurancetourix.hpp
+++ b/src/assurancetourix/assurancetourix/include/assurancetourix.hpp
@@ -114,6 +114,10 @@ private:
   std::string base_frame, header_frame_id, topic_for_gradient_layer, side, allies_positions_topic;
 
   rclcpp::Client<transformix_msgs::srv::TransformixParametersTransformStamped>::SharedPtr transformClient;
+
+#ifdef SIMULATION
+  rclcpp::Time get_sim_time(std::shared_ptr<webots::Robot> wb_robot);
+#endif /* SIMULATION */
 };
 
 #endif /* ONBOARD_VISION_NODE_HPP */

--- a/src/assurancetourix/assurancetourix/src/assurancetourix.cpp
+++ b/src/assurancetourix/assurancetourix/src/assurancetourix.cpp
@@ -135,10 +135,17 @@ void Assurancetourix::simulation_marker_callback() {
     x = wb_supervisor->getFromDef(robot)->getPosition()[0];
     y = 2 - wb_supervisor->getFromDef(robot)->getPosition()[2];
 
-    webots_marker.header.stamp = this->get_clock()->now();
+    webots_marker.header.stamp = get_sim_time(wb_supervisor);
+    tf2::Quaternion q;
+    q.setRPY(0, 0, theta);
+
+    webots_marker.pose.orientation.x = q.x();
+    webots_marker.pose.orientation.y = q.y();
+    webots_marker.pose.orientation.z = q.z();
+    webots_marker.pose.orientation.w = q.w();
+
     webots_marker.pose.position.x = x;
     webots_marker.pose.position.y = y;
-    webots_marker.pose.orientation.z = theta;
 
     webots_marker.text = robot;
     webots_marker.id = id;
@@ -147,7 +154,10 @@ void Assurancetourix::simulation_marker_callback() {
     id++;
   }
   id = 6;
-  webots_marker.pose.orientation.z = 0;
+  webots_marker.pose.orientation.x = 0.0;
+  webots_marker.pose.orientation.y = 0.0;
+  webots_marker.pose.orientation.z = 0.0;
+  webots_marker.pose.orientation.w = 1.0;
   webots_marker.header.stamp = this->get_clock()->now();
   if (comeback) {
     comeback_x += 0.1;
@@ -476,6 +486,14 @@ void Assurancetourix::_anotate_image(Mat img) {
     transformed_marker_pub_allies_->publish(marker_array_allies);
   }
 }
+
+#ifdef SIMULATION
+rclcpp::Time Assurancetourix::get_sim_time(std::shared_ptr<webots::Robot> wb_robot) {
+  double seconds = 0;
+  double nanosec = modf(wb_robot->getTime(), &seconds) * 1e9;
+  return rclcpp::Time((uint32_t)seconds, (uint32_t)nanosec);
+}
+#endif /* SIMULATION */
 
 Assurancetourix::~Assurancetourix() {
 #ifdef MIPI_CAMERA

--- a/src/modules/drive/CMakeLists.txt
+++ b/src/modules/drive/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
@@ -40,6 +41,7 @@ set(dependencies
   "sensor_msgs"
   "tf2"
   "tf2_msgs"
+  "tf2_ros"
   "tf2_geometry_msgs"
   "std_srvs"
   "diagnostic_msgs"

--- a/src/modules/drive/CMakeLists.txt
+++ b/src/modules/drive/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_msgs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(actuators_srvs REQUIRED)
@@ -39,6 +40,7 @@ set(dependencies
   "sensor_msgs"
   "tf2"
   "tf2_msgs"
+  "tf2_geometry_msgs"
   "std_srvs"
   "diagnostic_msgs"
   "actuators_srvs"

--- a/src/modules/drive/include/drive.hpp
+++ b/src/modules/drive/include/drive.hpp
@@ -182,6 +182,9 @@ private:
   void set_transform_from_pose(geometry_msgs::msg::PoseStamped &pose_in, geometry_msgs::msg::TransformStamped &transform_out);
   void get_pose_in_another_frame(geometry_msgs::msg::PoseStamped &pose_in, geometry_msgs::msg::PoseStamped &pose_out, geometry_msgs::msg::TransformStamped &transform);
   tf2::Quaternion get_tf2_quaternion(geometry_msgs::msg::Quaternion &q);
+  tf2::Vector3 get_tf2_vector(geometry_msgs::msg::Point &p);
+  tf2::Vector3 get_tf2_vector(geometry_msgs::msg::Vector3 &p);
+  void set_pose_from_tf_t_q(tf2::Vector3 &t, tf2::Quaternion &q, geometry_msgs::msg::PoseStamped &pose_out);
 
 #ifdef SIMULATION
   void sim_step();

--- a/src/modules/drive/include/drive.hpp
+++ b/src/modules/drive/include/drive.hpp
@@ -185,6 +185,7 @@ private:
   tf2::Vector3 get_tf2_vector(geometry_msgs::msg::Point &p);
   tf2::Vector3 get_tf2_vector(geometry_msgs::msg::Vector3 &p);
   void set_pose_from_tf_t_q(tf2::Vector3 &t, tf2::Quaternion &q, geometry_msgs::msg::PoseStamped &pose_out);
+  double dummy_tree_digits_precision(double a);
 
 #ifdef SIMULATION
   void sim_step();

--- a/src/modules/drive/include/drive.hpp
+++ b/src/modules/drive/include/drive.hpp
@@ -19,6 +19,7 @@
 #include <math.h>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
@@ -163,7 +164,7 @@ private:
   void init_variables();
   void update_tf();
   void update_joint_states();
-  void update_odometry();
+  void update_odometry(rclcpp::Time stamp = rclcpp::Time(0));
   void update_velocity();
   void update_diagnostic();
   void read_from_serial();

--- a/src/modules/drive/include/drive.hpp
+++ b/src/modules/drive/include/drive.hpp
@@ -19,6 +19,8 @@
 #include <math.h>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 

--- a/src/modules/drive/include/drive.hpp
+++ b/src/modules/drive/include/drive.hpp
@@ -109,9 +109,6 @@ private:
   // Sliders service
   rclcpp::Service<actuators_srvs::srv::Slider>::SharedPtr _set_slider_postion;
 
-  // Odometric adjustment
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr _adjust_odometry;
-
   rclcpp::TimerBase::SharedPtr diagnostics_timer_;
 
 #ifdef USE_TIMER
@@ -168,7 +165,7 @@ private:
   void init_variables();
   void update_tf();
   void update_joint_states();
-  void update_odometry(rclcpp::Time stamp = rclcpp::Time(0));
+  void update_odometry();
   void update_velocity();
   void update_diagnostic();
   void read_from_serial();
@@ -180,11 +177,11 @@ private:
                              const std_srvs::srv::SetBool::Response::SharedPtr response);
   void handle_set_slider_position(const std::shared_ptr<rmw_request_id_t> request_header, const actuators_srvs::srv::Slider::Request::SharedPtr request,
                                   const actuators_srvs::srv::Slider::Response::SharedPtr response);
-  void adjust_odometry(const std::shared_ptr<rmw_request_id_t> request_header, const std_srvs::srv::Trigger::Request::SharedPtr request,
-                             const std_srvs::srv::Trigger::Response::SharedPtr response);
   void adjust_odometry_callback(const geometry_msgs::msg::TransformStamped::SharedPtr tf_stamped_msg);
   void extract_pose_from_transform(geometry_msgs::msg::TransformStamped &transform_in, geometry_msgs::msg::PoseStamped &pose_out);
-  void set_transform_from_pose(geometry_msgs::msg::PoseStamped &pose_in, geometry_msgs::msg::TransformStamped &transform_out, rclcpp::Time &stamp);
+  void set_transform_from_pose(geometry_msgs::msg::PoseStamped &pose_in, geometry_msgs::msg::TransformStamped &transform_out);
+  void get_pose_in_another_frame(geometry_msgs::msg::PoseStamped &pose_in, geometry_msgs::msg::PoseStamped &pose_out, geometry_msgs::msg::TransformStamped &transform);
+  tf2::Quaternion get_tf2_quaternion(geometry_msgs::msg::Quaternion &q);
 
 #ifdef SIMULATION
   void sim_step();

--- a/src/modules/drive/include/drive.hpp
+++ b/src/modules/drive/include/drive.hpp
@@ -20,7 +20,10 @@
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_ros/static_transform_broadcaster.h>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
@@ -121,6 +124,7 @@ private:
   diagnostic_msgs::msg::DiagnosticStatus diagnostics_status_;
 
   /* Odometry re-adjustement */
+  geometry_msgs::msg::TransformStamped _map_to_odom_tf;
   std::vector<geometry_msgs::msg::TransformStamped> _previous_tf;
   rclcpp::Subscription<geometry_msgs::msg::TransformStamped>::SharedPtr _adjust_odometry_sub;
 

--- a/src/modules/drive/include/drive.hpp
+++ b/src/modules/drive/include/drive.hpp
@@ -10,6 +10,7 @@
 #include <webots/PositionSensor.hpp>
 #endif
 #include "std_srvs/srv/set_bool.hpp"
+#include "std_srvs/srv/trigger.hpp"
 #include "actuators_srvs/srv/slider.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/joint_state.hpp"
@@ -102,6 +103,9 @@ private:
   // Sliders service
   rclcpp::Service<actuators_srvs::srv::Slider>::SharedPtr _set_slider_postion;
 
+  // Odometric adjustment
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr _adjust_odometry;
+
   rclcpp::TimerBase::SharedPtr diagnostics_timer_;
 
 #ifdef USE_TIMER
@@ -165,6 +169,8 @@ private:
                              const std_srvs::srv::SetBool::Response::SharedPtr response);
   void handle_set_slider_position(const std::shared_ptr<rmw_request_id_t> request_header, const actuators_srvs::srv::Slider::Request::SharedPtr request,
                                   const actuators_srvs::srv::Slider::Response::SharedPtr response);
+  void adjust_odometry(const std::shared_ptr<rmw_request_id_t> request_header, const std_srvs::srv::Trigger::Request::SharedPtr request,
+                             const std_srvs::srv::Trigger::Response::SharedPtr response);
 
 #ifdef SIMULATION
   void sim_step();

--- a/src/modules/drive/include/drive.hpp
+++ b/src/modules/drive/include/drive.hpp
@@ -117,6 +117,10 @@ private:
   diagnostic_msgs::msg::DiagnosticArray diagnostics_array_;
   diagnostic_msgs::msg::DiagnosticStatus diagnostics_status_;
 
+  /* Odometry re-adjustement */
+  std::vector<geometry_msgs::msg::TransformStamped> _previous_tf;
+  rclcpp::Subscription<geometry_msgs::msg::TransformStamped>::SharedPtr _adjust_odometry_sub;
+
   double _accel;
   double _wheel_separation;
   double _wheel_radius;
@@ -171,6 +175,7 @@ private:
                                   const actuators_srvs::srv::Slider::Response::SharedPtr response);
   void adjust_odometry(const std::shared_ptr<rmw_request_id_t> request_header, const std_srvs::srv::Trigger::Request::SharedPtr request,
                              const std_srvs::srv::Trigger::Response::SharedPtr response);
+  void adjust_odometry_callback(const geometry_msgs::msg::TransformStamped::SharedPtr tf_stamped_msg);
 
 #ifdef SIMULATION
   void sim_step();

--- a/src/modules/drive/include/drive.hpp
+++ b/src/modules/drive/include/drive.hpp
@@ -176,6 +176,8 @@ private:
   void adjust_odometry(const std::shared_ptr<rmw_request_id_t> request_header, const std_srvs::srv::Trigger::Request::SharedPtr request,
                              const std_srvs::srv::Trigger::Response::SharedPtr response);
   void adjust_odometry_callback(const geometry_msgs::msg::TransformStamped::SharedPtr tf_stamped_msg);
+  void extract_pose_from_transform(geometry_msgs::msg::TransformStamped &transform_in, geometry_msgs::msg::PoseStamped &pose_out);
+  void set_transform_from_pose(geometry_msgs::msg::PoseStamped &pose_in, geometry_msgs::msg::TransformStamped &transform_out, rclcpp::Time &stamp);
 
 #ifdef SIMULATION
   void sim_step();

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -402,6 +402,19 @@ void Drive::set_transform_from_pose(geometry_msgs::msg::PoseStamped &pose_in, ge
 }
 
 void Drive::get_pose_in_another_frame(geometry_msgs::msg::PoseStamped &pose_in, geometry_msgs::msg::PoseStamped &pose_out, geometry_msgs::msg::TransformStamped &transform){
+  pose_out.header = pose_in.header;
+  pose_out.header.frame_id = transform.child_frame_id;
+
+  tf2::Vector3 t_in_new_frame,
+               t_pose_in = get_tf2_vector(pose_in.pose.position),
+               t_transform = get_tf2_vector(transform.transform.translation);
+  tf2::Quaternion q_in_new_frame,
+                  q_pose_in = get_tf2_quaternion(pose_in.pose.orientation),
+                  q_transform = get_tf2_quaternion(transform.transform.rotation);
+
+    t_in_new_frame = t_pose_in - t_transform;
+    q_in_new_frame = q_pose_in * q_transform.inverse();
+  set_pose_from_tf_t_q(t_in_new_frame, q_in_new_frame, pose_out);
 }
 
 tf2::Quaternion Drive::get_tf2_quaternion(geometry_msgs::msg::Quaternion &q){
@@ -417,6 +430,18 @@ tf2::Vector3 Drive::get_tf2_vector(geometry_msgs::msg::Vector3 &p){
 }
 
 void Drive::set_pose_from_tf_t_q(tf2::Vector3 &t, tf2::Quaternion &q, geometry_msgs::msg::PoseStamped &pose_out){
+  pose_out.pose.position.x = dummy_tree_digits_precision(t.x());
+  pose_out.pose.position.y = dummy_tree_digits_precision(t.y());
+  pose_out.pose.position.z = 0;
+  pose_out.pose.orientation.x = q.x();
+  pose_out.pose.orientation.y = q.y();
+  pose_out.pose.orientation.z = q.z();
+  pose_out.pose.orientation.w = q.w();
+}
+
+double Drive::dummy_tree_digits_precision(double a){
+  int dummy = (int)(a*1000);
+  return (double)(dummy)/1000;
 }
 
 Drive::~Drive() {

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -60,6 +60,9 @@ Drive::Drive() : Node("drive_node") {
   _set_slider_postion = this->create_service<actuators_srvs::srv::Slider>(
       "slider_position", std::bind(&Drive::handle_set_slider_position, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
+  _adjust_odometry = this->create_service<std_srvs::srv::Trigger>(
+      "adjust_odometry", std::bind(&Drive::adjust_odometry, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+
   diagnostics_timer_ = this->create_wall_timer(1s, std::bind(&Drive::update_diagnostic, this));
 
 #ifdef USE_TIMER
@@ -314,6 +317,15 @@ rclcpp::Time Drive::get_sim_time() {
 
 void Drive::sim_step() { this->wb_robot->step(timestep); }
 #endif /* SIMULATION */
+
+void Drive::adjust_odometry(const std::shared_ptr<rmw_request_id_t> request_header, const std_srvs::srv::Trigger::Request::SharedPtr request,
+                            const std_srvs::srv::Trigger::Response::SharedPtr response) {
+
+  odom_pose_.x = 0;
+  odom_pose_.y = 0;
+  odom_pose_.thetha = 0;
+  response->success = true;
+}
 
 Drive::~Drive() {
 #ifndef SIMULATION

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -348,6 +348,22 @@ void Drive::adjust_odometry_callback(const geometry_msgs::msg::TransformStamped:
     if (stamp_msg - (rclcpp::Time)_previous_tf[right_stamp_index].header.stamp
       > (rclcpp::Time)_previous_tf[right_stamp_index - 1].header.stamp - stamp_msg) right_stamp_index--;
   }
+void Drive::extract_pose_from_transform(geometry_msgs::msg::TransformStamped &transform_in, geometry_msgs::msg::PoseStamped &pose_out){
+  pose_out.header = transform_in.header;
+  pose_out.pose.position.x = transform_in.transform.translation.x;
+  pose_out.pose.position.y = transform_in.transform.translation.y;
+  pose_out.pose.position.z = transform_in.transform.translation.z;
+  pose_out.pose.orientation = transform_in.transform.rotation;
+}
+
+void Drive::set_transform_from_pose(geometry_msgs::msg::PoseStamped &pose_in, geometry_msgs::msg::TransformStamped &transform_out, rclcpp::Time &stamp){
+  transform_out.header.stamp = stamp;
+  transform_out.header.frame_id = odom_.header.frame_id;
+  transform_out.child_frame_id = odom_.child_frame_id;
+  transform_out.transform.translation.x = pose_in.pose.position.x;
+  transform_out.transform.translation.y = pose_in.pose.position.y;
+  transform_out.transform.translation.z = pose_in.pose.position.z;
+  transform_out.transform.rotation = pose_in.pose.orientation;
 }
 
 

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -348,6 +348,21 @@ void Drive::adjust_odometry_callback(const geometry_msgs::msg::TransformStamped:
     if (stamp_msg - (rclcpp::Time)_previous_tf[right_stamp_index].header.stamp
       > (rclcpp::Time)_previous_tf[right_stamp_index - 1].header.stamp - stamp_msg) right_stamp_index--;
   }
+
+  //stamp_msg = this->get_clock()->now();
+  geometry_msgs::msg::TransformStamped base_link_odom_tf,
+                                       tf_msg = *tf_stamped_msg,
+                                       nearest_tf = _previous_tf[right_stamp_index];
+  //tf_msg.header.stamp = this->get_clock()->now();
+
+  geometry_msgs::msg::PoseStamped base_link_relative_to_old_odom, base_link_relative_to_new_odom;
+  extract_pose_from_transform(_previous_tf[0], base_link_relative_to_old_odom);
+
+  tf2::doTransform<geometry_msgs::msg::PoseStamped>(base_link_relative_to_old_odom, base_link_relative_to_new_odom, nearest_tf);
+
+  //rclcpp::Time base_link_odom_tf_stamp = (rclcpp::Time)_previous_tf[right_stamp_index].header.stamp;
+  set_transform_from_pose(base_link_relative_to_new_odom, base_link_odom_tf, stamp_msg);
+
 void Drive::extract_pose_from_transform(geometry_msgs::msg::TransformStamped &transform_in, geometry_msgs::msg::PoseStamped &pose_out){
   pose_out.header = transform_in.header;
   pose_out.pose.position.x = transform_in.transform.translation.x;

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -145,7 +145,7 @@ void Drive::init_variables() {
   init_vector.header.stamp = this->get_clock()->now();
   init_vector.header.frame_id = odom_.header.frame_id;
   init_vector.child_frame_id = odom_.child_frame_id;
-  for (int i = 0; i<20; i++) _previous_tf.push_back(init_vector);
+  for (int i = 0; i<30; i++) _previous_tf.push_back(init_vector);
 }
 
 int8_t Drive::compute_velocity_cmd(double velocity) {
@@ -275,7 +275,7 @@ void Drive::update_tf() {
   tf_pub_->publish(odom_tf_msg);
 
   _previous_tf.insert(_previous_tf.begin(), odom_tf);
-  if (_previous_tf.size() > 20) _previous_tf.pop_back();
+  if (_previous_tf.size() > 30) _previous_tf.pop_back();
 }
 
 void Drive::update_joint_states() {
@@ -418,7 +418,7 @@ void Drive::get_pose_in_another_frame(geometry_msgs::msg::PoseStamped &pose_in, 
     t_in_new_frame = t_pose_in + t_transform;
   }
 
-  if (pose_in.header.frame_id == odom_.child_frame_id){
+  if (pose_in.header.frame_id == odom_.child_frame_id || pose_in.header.frame_id == transform.header.frame_id){
     q_in_new_frame = q_transform * q_pose_in.inverse();
   } else {
     q_in_new_frame = q_pose_in * q_transform.inverse();

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -336,15 +336,18 @@ void Drive::adjust_odometry(const std::shared_ptr<rmw_request_id_t> request_head
 void Drive::adjust_odometry_callback(const geometry_msgs::msg::TransformStamped::SharedPtr tf_stamped_msg){
   rclcpp::Time stamp_msg = tf_stamped_msg->header.stamp;
   int right_stamp_index = 0;
-  while (right_stamp_index < _previous_tf.size() && stamp_msg < _previous_tf[right_stamp_index].header.stamp){
+  while (stamp_msg < (rclcpp::Time)_previous_tf.at(right_stamp_index).header.stamp){
     right_stamp_index++;
     if (right_stamp_index == _previous_tf.size()) {
       RCLCPP_WARN(this->get_logger(), "Not enough tf stored to readjust odometry");
       return;
     }
   }
-  
 
+  if (right_stamp_index != 0){
+    if (stamp_msg - (rclcpp::Time)_previous_tf[right_stamp_index].header.stamp
+      > (rclcpp::Time)_previous_tf[right_stamp_index - 1].header.stamp - stamp_msg) right_stamp_index--;
+  }
 }
 
 

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -60,9 +60,6 @@ Drive::Drive() : Node("drive_node") {
   _set_slider_postion = this->create_service<actuators_srvs::srv::Slider>(
       "slider_position", std::bind(&Drive::handle_set_slider_position, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
-  _adjust_odometry = this->create_service<std_srvs::srv::Trigger>(
-      "adjust_odometry", std::bind(&Drive::adjust_odometry, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-
   _adjust_odometry_sub = this->create_subscription<geometry_msgs::msg::TransformStamped>(
       "adjust_odometry", qos, std::bind(&Drive::adjust_odometry_callback, this, std::placeholders::_1));
 
@@ -329,15 +326,6 @@ rclcpp::Time Drive::get_sim_time() {
 
 void Drive::sim_step() { this->wb_robot->step(timestep); }
 #endif /* SIMULATION */
-
-void Drive::adjust_odometry(const std::shared_ptr<rmw_request_id_t> request_header, const std_srvs::srv::Trigger::Request::SharedPtr request,
-                            const std_srvs::srv::Trigger::Response::SharedPtr response) {
-
-  odom_pose_.x = 0;
-  odom_pose_.y = 0;
-  odom_pose_.thetha = 0;
-  response->success = true;
-}
 
 void Drive::adjust_odometry_callback(const geometry_msgs::msg::TransformStamped::SharedPtr tf_stamped_msg){
   rclcpp::Time stamp_msg = tf_stamped_msg->header.stamp;

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -379,10 +379,8 @@ void Drive::adjust_odometry_callback(const geometry_msgs::msg::TransformStamped:
   double roll, pitch, yaw;
   m.getRPY(roll, pitch, yaw);
   odom_pose_.thetha = yaw;
-  odom_pose_.x = base_link_odom_tf.transform.translation.x;
-  odom_pose_.y = base_link_odom_tf.transform.translation.y;
-  update_odometry(stamp_msg);
-  tf_pub_->publish(odom_tf_msg);
+  odom_pose_.x = base_link_relative_to_odom_corrected.pose.position.x;
+  odom_pose_.y = base_link_relative_to_odom_corrected.pose.position.y;
 }
 
 void Drive::extract_pose_from_transform(geometry_msgs::msg::TransformStamped &transform_in, geometry_msgs::msg::PoseStamped &pose_out){
@@ -393,8 +391,7 @@ void Drive::extract_pose_from_transform(geometry_msgs::msg::TransformStamped &tr
   pose_out.pose.orientation = transform_in.transform.rotation;
 }
 
-void Drive::set_transform_from_pose(geometry_msgs::msg::PoseStamped &pose_in, geometry_msgs::msg::TransformStamped &transform_out, rclcpp::Time &stamp){
-  transform_out.header.stamp = stamp;
+void Drive::set_transform_from_pose(geometry_msgs::msg::PoseStamped &pose_in, geometry_msgs::msg::TransformStamped &transform_out){
   transform_out.header.frame_id = odom_.header.frame_id;
   transform_out.child_frame_id = odom_.child_frame_id;
   transform_out.transform.translation.x = pose_in.pose.position.x;

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -360,14 +360,10 @@ void Drive::adjust_odometry_callback(const geometry_msgs::msg::TransformStamped:
   geometry_msgs::msg::PoseStamped base_link_relative_to_old_odom, base_link_relative_to_new_odom;
   extract_pose_from_transform(_previous_tf[0], base_link_relative_to_old_odom);
 
-  tf2::doTransform<geometry_msgs::msg::PoseStamped>(base_link_relative_to_old_odom, base_link_relative_to_new_odom, nearest_tf);
 
   //rclcpp::Time base_link_odom_tf_stamp = (rclcpp::Time)_previous_tf[right_stamp_index].header.stamp;
   set_transform_from_pose(base_link_relative_to_new_odom, base_link_odom_tf, stamp_msg);
 
-  tf2_msgs::msg::TFMessage odom_tf_msg;
-  odom_tf_msg.transforms.push_back(tf_msg);
-  odom_tf_msg.transforms.push_back(base_link_odom_tf);
 
   tf2::Quaternion q(
     base_link_odom_tf.transform.rotation.x,

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -135,6 +135,11 @@ void Drive::init_variables() {
 #else
   time_since_last_sync_ = get_sim_time();
 #endif /* SIMULATION */
+  geometry_msgs::msg::TransformStamped init_vector;
+  init_vector.header.stamp = this->get_clock()->now();
+  init_vector.header.frame_id = odom_.header.frame_id;
+  init_vector.child_frame_id = odom_.child_frame_id;
+  for (int i = 0; i<20; i++) _previous_tf.push_back(init_vector);
 }
 
 int8_t Drive::compute_velocity_cmd(double velocity) {

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -412,8 +412,19 @@ void Drive::get_pose_in_another_frame(geometry_msgs::msg::PoseStamped &pose_in, 
                   q_pose_in = get_tf2_quaternion(pose_in.pose.orientation),
                   q_transform = get_tf2_quaternion(transform.transform.rotation);
 
+  if (pose_in.header.frame_id == transform.header.frame_id){
     t_in_new_frame = t_pose_in - t_transform;
+  } else {
+    t_in_new_frame = t_pose_in + t_transform;
+  }
+
+  if (pose_in.header.frame_id == odom_.child_frame_id){
+    q_in_new_frame = q_transform * q_pose_in.inverse();
+  } else {
     q_in_new_frame = q_pose_in * q_transform.inverse();
+  }
+
+
   set_pose_from_tf_t_q(t_in_new_frame, q_in_new_frame, pose_out);
 }
 

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -241,7 +241,7 @@ void Drive::compute_pose_velocity(TinyData steps_returned) {
   odom_pose_.thetha += instantaneous_move_.angular;
 }
 
-void Drive::update_odometry(rclcpp::Time stamp) {
+void Drive::update_odometry() {
   odom_.pose.pose.position.x = odom_pose_.x;
   odom_.pose.pose.position.y = odom_pose_.y;
   odom_.pose.pose.position.z = 0;
@@ -257,8 +257,7 @@ void Drive::update_odometry(rclcpp::Time stamp) {
   // We should update the twist of the odometry
   odom_.twist.twist.linear.x = instantaneous_speed_.linear;
   odom_.twist.twist.angular.z = instantaneous_speed_.angular;
-  if (stamp.nanoseconds() == 0) odom_.header.stamp = time_since_last_sync_;
-  else odom_.header.stamp = stamp;
+  odom_.header.stamp = time_since_last_sync_;
   odom_pub_->publish(odom_);
 }
 

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -132,6 +132,15 @@ void Drive::init_variables() {
 #else
   time_since_last_sync_ = get_sim_time();
 #endif /* SIMULATION */
+
+  tf2_ros::Buffer tfBuffer(std::make_shared<rclcpp::Clock>(), tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME));
+  tf2_ros::TransformListener tfListener(tfBuffer);
+  std::string errorMsg;
+  if(tfBuffer.canTransform(odom_.header.frame_id, "map", std::chrono::system_clock::now(), std::chrono::milliseconds(10000)))
+  {
+    _map_to_odom_tf = tfBuffer.lookupTransform(odom_.header.frame_id, "map", std::chrono::system_clock::now(), std::chrono::milliseconds(10000));
+  }
+
   geometry_msgs::msg::TransformStamped init_vector;
   init_vector.header.stamp = this->get_clock()->now();
   init_vector.header.frame_id = odom_.header.frame_id;

--- a/src/modules/drive/src/drive.cpp
+++ b/src/modules/drive/src/drive.cpp
@@ -396,6 +396,23 @@ void Drive::set_transform_from_pose(geometry_msgs::msg::PoseStamped &pose_in, ge
   transform_out.transform.rotation = pose_in.pose.orientation;
 }
 
+void Drive::get_pose_in_another_frame(geometry_msgs::msg::PoseStamped &pose_in, geometry_msgs::msg::PoseStamped &pose_out, geometry_msgs::msg::TransformStamped &transform){
+}
+
+tf2::Quaternion Drive::get_tf2_quaternion(geometry_msgs::msg::Quaternion &q){
+  return tf2::Quaternion(q.x,q.y,q.z,q.w);
+}
+
+tf2::Vector3 Drive::get_tf2_vector(geometry_msgs::msg::Point &p){
+  return tf2::Vector3(p.x, p.y, p.z);
+}
+
+tf2::Vector3 Drive::get_tf2_vector(geometry_msgs::msg::Vector3 &p){
+  return tf2::Vector3(p.x, p.y, p.z);
+}
+
+void Drive::set_pose_from_tf_t_q(tf2::Vector3 &t, tf2::Quaternion &q, geometry_msgs::msg::PoseStamped &pose_out){
+}
 
 Drive::~Drive() {
 #ifndef SIMULATION

--- a/src/modules/localisation/localisation/localisation_node.py
+++ b/src/modules/localisation/localisation/localisation_node.py
@@ -12,8 +12,6 @@ from rcl_interfaces.msg import SetParametersResult
 from visualization_msgs.msg import MarkerArray
 from tf2_ros import StaticTransformBroadcaster
 from tf2_ros import TransformBroadcaster
-from std_srvs.srv import Trigger
-
 
 class Localisation(rclpy.node.Node):
     """Robot localisation node."""
@@ -35,8 +33,6 @@ class Localisation(rclpy.node.Node):
         self.subscription_  # prevent unused variable warning
         self.last_odom_update = self.get_clock().now().to_msg().sec;
         self.create_timer(1, self.update_transform)
-        self._get_trigger_adjust_odometry_request = Trigger.Request()
-        self._get_trigger_adjust_odometry_client = self.create_client(Trigger, 'adjust_odometry')
         self.tf_publisher_ = self.create_publisher(TransformStamped, 'adjust_odometry', 10)
         self.update_transform()
         self.get_logger().info(f'Default side is {self.side.value}')

--- a/src/modules/localisation/localisation/localisation_node.py
+++ b/src/modules/localisation/localisation/localisation_node.py
@@ -11,7 +11,6 @@ from geometry_msgs.msg import TransformStamped
 from rcl_interfaces.msg import SetParametersResult
 from visualization_msgs.msg import MarkerArray
 from tf2_ros import StaticTransformBroadcaster
-from tf2_ros import TransformBroadcaster
 
 class Localisation(rclpy.node.Node):
     """Robot localisation node."""
@@ -23,7 +22,6 @@ class Localisation(rclpy.node.Node):
         self.add_on_set_parameters_callback(self._on_set_parameters)
         self._x, self._y, self._theta = self.fetchStartPosition()
         self._tf_brodcaster = StaticTransformBroadcaster(self)
-        self._tf_brodcaster = TransformBroadcaster(self)
         self._tf = TransformStamped()
         self._tf.header.frame_id = 'map'
         self._tf.child_frame_id = 'odom'

--- a/src/modules/localisation/localisation/localisation_node.py
+++ b/src/modules/localisation/localisation/localisation_node.py
@@ -4,6 +4,7 @@
 """Robot localisation node."""
 
 
+import math
 import numpy as np
 
 import rclpy
@@ -29,10 +30,7 @@ class Localisation(rclpy.node.Node):
         self.subscription_ = self.create_subscription(
             MarkerArray, '/allies_positions_markers', self.allies_subscription_callback, 10)
         self.subscription_  # prevent unused variable warning
-        self.last_odom_update = self.get_clock().now().to_msg().sec;
-        self.create_timer(1, self.update_transform)
         self.tf_publisher_ = self.create_publisher(TransformStamped, 'adjust_odometry', 10)
-        self.update_transform()
         self.get_logger().info(f'Default side is {self.side.value}')
         self.get_logger().info('Localisation node is ready')
 
@@ -109,11 +107,6 @@ class Localisation(rclpy.node.Node):
         self._tf.transform.rotation.z = float(qz)
         self._tf.transform.rotation.w = float(qw)
         self._tf_brodcaster.sendTransform(self._tf)
-        #self.get_logger().info(f'tf: x={self.get_clock().now().to_msg().sec}')
-
-    def _service_call(self, client, request):
-        """Call service synchronously."""
-        client.call_async(request)
 
     def allies_subscription_callback(self, msg):
         for allie_marker in msg.markers:

--- a/src/modules/robot/param/robot.in.yml
+++ b/src/modules/robot/param/robot.in.yml
@@ -92,14 +92,15 @@ controller_server:
       # Optimisation
       optimization_activate: True
       optimization_verbose: False
-      #weight_shortest_path: 500.0
+      weight_kinematics_forward_drive: 0.0
 
       # Trajectory
       teb_autoresize: True
       exact_arc_length: False
       min_samples: 3
       max_samples: 100
-      max_global_plan_lookahead_dist: 1.0
+      max_global_plan_lookahead_dist: 3.7
+      global_plan_overwrite_orientation: true
       allow_init_with_backwards_motion: true
 
 
@@ -139,19 +140,15 @@ global_costmap:
 local_costmap: #just enough parameters to disable it
   local_costmap:
     ros__parameters:
-      update_frequency: 2.0
-      publish_frequency: 2.0
-      global_frame: odom
+      update_frequency: 0.1
+      publish_frequency: 0.1
+      global_frame: map
       robot_base_frame: base_link
-      use_sim_time: !Var use_sim_time
+      use_sim_time: false
       rolling_window: true
-      width: 3
-      height: 3
-      resolution: 0.02
-      plugins: ["static_layer"]
-      static_layer:
-        plugin: "nav2_costmap_2d::StaticLayer"
-        map_subscribe_transient_local: True
+      width: 6
+      height: 6
+      resolution: 1.0
 
 map_server:
   ros__parameters:

--- a/src/modules/robot/param/robot.in.yml
+++ b/src/modules/robot/param/robot.in.yml
@@ -57,41 +57,50 @@ controller_server:
   ros__parameters:
     use_sim_time: !Var use_sim_time
     controller_frequency: 40.0
+    min_x_velocity_threshold: 0.001
+    min_y_velocity_threshold: 0.5
+    min_theta_velocity_threshold: 0.001
+    progress_checker_plugin: "progress_checker"
+    goal_checker_plugin: "goal_checker"
     controller_plugins: ["DynamicFollowPath"]
-
+    progress_checker:
+      plugin: "nav2_controller::SimpleProgressChecker"
+      required_movement_radius: 0.5
+      movement_time_allowance: 10.0
+    goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.02
+      yaw_goal_tolerance: 0.02
+      stateful: True
     DynamicFollowPath:
       plugin: "teb_local_planner::TebLocalPlannerROS"
       # Robot footprint
       footprint_model.type: polygon
-
-      # Goal tolerance
-      xy_goal_tolerance: 0.02
-      yaw_goal_tolerance: 0.05
 
       # Obstacles
       min_obstacle_dist: 0.01
       inflation_dist: 0.1
       costmap_converter_plugin: costmap_converter::CostmapToPolygonsDBSMCCH
       costmap_converter_spin_thread: True
-      costmap_converter_rate: 2
+      costmap_converter_rate: 5
 
       # Homotopy Class Planner
       enable_homotopy_class_planning: True
       enable_multithreading: True
-      visualize_hc_graph: False
+      delete_detours_backwards: True
 
       # Optimisation
       optimization_activate: True
       optimization_verbose: False
+      #weight_shortest_path: 500.0
 
       # Trajectory
       teb_autoresize: True
       exact_arc_length: False
       min_samples: 3
-      max_samples: 20
+      max_samples: 100
       max_global_plan_lookahead_dist: 1.0
-      allow_init_with_backwards_motion: True
-      global_plan_overwrite_orientation: True
+      allow_init_with_backwards_motion: true
 
 
 controller_server_rclcpp_node:
@@ -102,23 +111,30 @@ controller_server_rclcpp_node:
 global_costmap:
   global_costmap:
     ros__parameters:
-      update_frequency: 2.0
-      publish_frequency: 2.0
+      update_frequency: 5.0
+      publish_frequency: 5.0
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: !Var use_sim_time
       resolution: 0.02
-      plugins: ["static_layer", "gradient_layer"]
+      plugins: ["static_layer", "gradient_layer", "inflation_layer"]
       static_layer: #subscribe to map
         plugin: "nav2_costmap_2d::StaticLayer"
         map_subscribe_transient_local: True
       gradient_layer: #draw radians circle around ennemies
         plugin: "gradient_costmap_layer_plugin/GradientLayer"
         enabled: true
-        gradient_size: 15
+        gradient_size: 7
         gradient_factor: 100
         markers_topic: /ennemies_positions_markers
-      always_send_full_costmap: True
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        enabled: true
+        inflation_radius: 0.2
+        cost_scaling_factor: 5.0
+        inflate_unknown: false
+        inflate_around_unknown: false
+      always_send_full_costmap: true
 
 local_costmap: #just enough parameters to disable it
   local_costmap:


### PR DESCRIPTION
## Idea
The idea is to give to drive the real position of the robot at a given stamp. The goal for drive is to set odom_pose_ with this information.

## Problem:
The position given is obviously from the past.

## Solution: 
- Store the last 30 transforms from odom to base_link,
- Retrieve the nearest stored tf from the given TransformStamped (tf_stamped_msg),
- Getting tf_stamped_msg relative to odom,
- Getting the last position of base_link relative to the nearest stored tf retrieve previously,
- Getting the new position of base_link relative to odom which is corrected,
- Finally set the new odom_pose_ with the new position of base_link.

## Observations
The goal of this method isn't to perfectly re-adjust the odometry, but to reduce the error of the odometry between the last re-adjustment and the nearest stored tf from the stamp of the given TransformStamped. 
This can re-adjust odometry  up to 0.75s from the past.