### PR TITLE
Update ros_ws.repos

### DIFF
--- a/ros_ws.repos
+++ b/ros_ws.repos
@@ -1,49 +1,57 @@
 repositories:
-  BehaviorTree.CPP:
+  BehaviorTree/BehaviorTree.CPP:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
     version: master
-  angles:
+  ros/angles:
     type: git
     url: https://github.com/ros/angles.git
     version: ros2
-  costmap_converter:
+  nav/costmap_converter:
     type: git
     url: https://github.com/rst-tu-dortmund/costmap_converter.git
     version: ros2
-  image_common:
+  ros-perception/image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
     version: ros2
-  libg2o-release:
+  nav/libg2o-release:
     type: git
     url: https://github.com/ros2-gbp/libg2o-release.git
     version: debian/foxy/libg2o
-  navigation2:
+  nav/navigation2:
     type: git
     url: https://github.com/ros-planning/navigation2.git
-    version: fa1a64ad4d47a3793d22ce7da3f7238c92294af7
-  pending_release/py_trees:
+    version: foxy-devel
+  py_trees/py_trees:
     type: git
     url: https://github.com/splintered-reality/py_trees.git
     version: release/2.1.x
-  pending_release/py_trees_ros:
+  py_trees/py_trees_ros:
     type: git
     url: https://github.com/splintered-reality/py_trees_ros.git
     version: release/2.1.x
-  pending_release/py_trees_ros_interfaces:
+  py_trees/py_trees_ros_interfaces:
     type: git
     url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
     version: release/2.0.x
-  teb_local_planner:
+  nav/teb_local_planner:
     type: git
     url: https://github.com/robotique-ecam/teb_local_planner.git
     version: foxy
-  vision_opencv:
+  ros-perception/vision_opencv:
     type: git
     url: https://github.com/ros-perception/vision_opencv.git
     version: ros2
-  xacro:
+  ros/xacro:
     type: git
     url: https://github.com/ros/xacro.git
     version: dashing-devel
+  nav/ompl:
+    type: git
+    url: https://github.com/ompl/ompl.git
+    version: 1.5.0
+  ros/bond_core:
+    type: git
+    url: https://github.com/ros/bond_core.git
+    version: ros2

--- a/ros_ws.repos
+++ b/ros_ws.repos
@@ -3,17 +3,9 @@ repositories:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
     version: master
-  ros/angles:
-    type: git
-    url: https://github.com/ros/angles.git
-    version: ros2
   nav/costmap_converter:
     type: git
     url: https://github.com/rst-tu-dortmund/costmap_converter.git
-    version: ros2
-  ros-perception/image_common:
-    type: git
-    url: https://github.com/ros-perception/image_common.git
     version: ros2
   nav/libg2o-release:
     type: git
@@ -23,6 +15,14 @@ repositories:
     type: git
     url: https://github.com/ros-planning/navigation2.git
     version: foxy-devel
+  nav/ompl:
+    type: git
+    url: https://github.com/ompl/ompl.git
+    version: 1.5.0
+  nav/teb_local_planner:
+    type: git
+    url: https://github.com/robotique-ecam/teb_local_planner.git
+    version: foxy
   py_trees/py_trees:
     type: git
     url: https://github.com/splintered-reality/py_trees.git
@@ -35,23 +35,23 @@ repositories:
     type: git
     url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
     version: release/2.0.x
-  nav/teb_local_planner:
+  ros-perception/image_common:
     type: git
-    url: https://github.com/robotique-ecam/teb_local_planner.git
-    version: foxy
+    url: https://github.com/ros-perception/image_common.git
+    version: ros2
   ros-perception/vision_opencv:
     type: git
     url: https://github.com/ros-perception/vision_opencv.git
+    version: ros2
+  ros/angles:
+    type: git
+    url: https://github.com/ros/angles.git
+    version: ros2
+  ros/bond_core:
+    type: git
+    url: https://github.com/ros/bond_core.git
     version: ros2
   ros/xacro:
     type: git
     url: https://github.com/ros/xacro.git
     version: dashing-devel
-  nav/ompl:
-    type: git
-    url: https://github.com/ompl/ompl.git
-    version: 1.5.0
-  ros/bond_core:
-    type: git
-    url: https://github.com/ros/bond_core.git
-    version: ros2

--- a/ros_ws.repos
+++ b/ros_ws.repos
@@ -22,7 +22,7 @@ repositories:
   nav/teb_local_planner:
     type: git
     url: https://github.com/robotique-ecam/teb_local_planner.git
-    version: foxy
+    version: foxy-devel
   py_trees/py_trees:
     type: git
     url: https://github.com/splintered-reality/py_trees.git

--- a/ros_ws.repos
+++ b/ros_ws.repos
@@ -19,6 +19,10 @@ repositories:
     type: git
     url: https://github.com/ompl/ompl.git
     version: 1.5.0
+  nav/slam_toolbox:
+    type: git
+    url: https://github.com/SteveMacenski/slam_toolbox.git
+    version: ros2
   nav/teb_local_planner:
     type: git
     url: https://github.com/robotique-ecam/teb_local_planner.git


### PR DESCRIPTION
Necessary update prior to adding [ros_ws.repos](https://raw.githubusercontent.com/robotique-ecam/cdfr/master/ros_ws.repos) to the builder [ros-base-packages](https://github.com/robotique-ecam/ros2-base-packages)

This is the first step towards packaging the built aarch64 (ARM64) packages as Debian packages (.deb). Those packages will be distributed by [mothership](https://github.com/robotique-ecam/mothership)