### PR TITLE
Build libceres-dev as N/A on Debian buster aarch64

### DIFF
--- a/ros_ws.repos
+++ b/ros_ws.repos
@@ -3,17 +3,9 @@ repositories:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
     version: master
-  ros/angles:
-    type: git
-    url: https://github.com/ros/angles.git
-    version: ros2
   nav/costmap_converter:
     type: git
     url: https://github.com/rst-tu-dortmund/costmap_converter.git
-    version: ros2
-  ros-perception/image_common:
-    type: git
-    url: https://github.com/ros-perception/image_common.git
     version: ros2
   nav/libg2o-release:
     type: git
@@ -23,6 +15,14 @@ repositories:
     type: git
     url: https://github.com/ros-planning/navigation2.git
     version: foxy-devel
+  nav/ompl:
+    type: git
+    url: https://github.com/ompl/ompl.git
+    version: 1.5.0
+  nav/teb_local_planner:
+    type: git
+    url: https://github.com/robotique-ecam/teb_local_planner.git
+    version: foxy
   py_trees/py_trees:
     type: git
     url: https://github.com/splintered-reality/py_trees.git
@@ -35,23 +35,23 @@ repositories:
     type: git
     url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
     version: release/2.0.x
-  nav/teb_local_planner:
+  ros-perception/image_common:
     type: git
-    url: https://github.com/robotique-ecam/teb_local_planner.git
-    version: foxy
+    url: https://github.com/ros-perception/image_common.git
+    version: ros2
   ros-perception/vision_opencv:
     type: git
     url: https://github.com/ros-perception/vision_opencv.git
+    version: ros2
+  ros/angles:
+    type: git
+    url: https://github.com/ros/angles.git
+    version: ros2
+  ros/bond_core:
+    type: git
+    url: https://github.com/ros/bond_core.git
     version: ros2
   ros/xacro:
     type: git
     url: https://github.com/ros/xacro.git
     version: dashing-devel
-  nav/ompl:
-    type: git
-    url: https://github.com/ompl/ompl.git
-    version: 1.5.0
-  ros/bond_core:
-    type: git
-    url: https://github.com/ros/bond_core.git
-    version: ros2

--- a/ros_ws.repos
+++ b/ros_ws.repos
@@ -22,7 +22,7 @@ repositories:
   nav/teb_local_planner:
     type: git
     url: https://github.com/robotique-ecam/teb_local_planner.git
-    version: foxy
+    version: foxy-devel
   py_trees/py_trees:
     type: git
     url: https://github.com/splintered-reality/py_trees.git

--- a/ros_ws.repos
+++ b/ros_ws.repos
@@ -3,9 +3,17 @@ repositories:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
     version: master
+  ros/angles:
+    type: git
+    url: https://github.com/ros/angles.git
+    version: ros2
   nav/costmap_converter:
     type: git
     url: https://github.com/rst-tu-dortmund/costmap_converter.git
+    version: ros2
+  ros-perception/image_common:
+    type: git
+    url: https://github.com/ros-perception/image_common.git
     version: ros2
   nav/libg2o-release:
     type: git
@@ -14,18 +22,6 @@ repositories:
   nav/navigation2:
     type: git
     url: https://github.com/ros-planning/navigation2.git
-    version: foxy-devel
-  nav/ompl:
-    type: git
-    url: https://github.com/ompl/ompl.git
-    version: 1.5.0
-  nav/slam_toolbox:
-    type: git
-    url: https://github.com/SteveMacenski/slam_toolbox.git
-    version: ros2
-  nav/teb_local_planner:
-    type: git
-    url: https://github.com/robotique-ecam/teb_local_planner.git
     version: foxy-devel
   py_trees/py_trees:
     type: git
@@ -39,23 +35,23 @@ repositories:
     type: git
     url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
     version: release/2.0.x
-  ros-perception/image_common:
+  nav/teb_local_planner:
     type: git
-    url: https://github.com/ros-perception/image_common.git
-    version: ros2
+    url: https://github.com/robotique-ecam/teb_local_planner.git
+    version: foxy
   ros-perception/vision_opencv:
     type: git
     url: https://github.com/ros-perception/vision_opencv.git
-    version: ros2
-  ros/angles:
-    type: git
-    url: https://github.com/ros/angles.git
-    version: ros2
-  ros/bond_core:
-    type: git
-    url: https://github.com/ros/bond_core.git
     version: ros2
   ros/xacro:
     type: git
     url: https://github.com/ros/xacro.git
     version: dashing-devel
+  nav/ompl:
+    type: git
+    url: https://github.com/ompl/ompl.git
+    version: 1.5.0
+  ros/bond_core:
+    type: git
+    url: https://github.com/ros/bond_core.git
+    version: ros2

--- a/ros_ws.repos
+++ b/ros_ws.repos
@@ -3,6 +3,10 @@ repositories:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
     version: master
+  nav/ceres-solver:
+    type: git
+    url: https://github.com/ceres-solver/ceres-solver.git
+    version: 1.14.x
   nav/costmap_converter:
     type: git
     url: https://github.com/rst-tu-dortmund/costmap_converter.git

--- a/ros_ws.repos
+++ b/ros_ws.repos
@@ -19,6 +19,10 @@ repositories:
     type: git
     url: https://github.com/ompl/ompl.git
     version: 1.5.0
+  nav/slam_toolbox:
+    type: git
+    url: https://github.com/SteveMacenski/slam_toolbox.git
+    version: ros2
   nav/teb_local_planner:
     type: git
     url: https://github.com/robotique-ecam/teb_local_planner.git


### PR DESCRIPTION
There is a missing dependency on buster but only for aarch64, let's build it ourselves then

See [https://packages.debian.org/buster/libceres-dev]()