### PR TITLE
[CI] Fail in case of process crash

### DIFF
--- a/src/titan/launch/cloud-interfaces.py
+++ b/src/titan/launch/cloud-interfaces.py
@@ -17,7 +17,7 @@ from launch.actions import (
 )
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
-from launch.event import Shutdown
+from launch.events import Shutdown
 from launch.event_handlers import OnProcessExit
 
 

--- a/src/titan/launch/cloud-interfaces.py
+++ b/src/titan/launch/cloud-interfaces.py
@@ -9,9 +9,17 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 import launch
-from launch.actions import GroupAction, IncludeLaunchDescription
+from launch.actions import (
+    GroupAction,
+    IncludeLaunchDescription,
+    RegisterEventHandler,
+    EmitEvent,
+)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
+from launch.event import Shutdown
+from launch.event_handlers import OnProcessExit
+
 
 robots = ["asterix"]
 
@@ -46,6 +54,15 @@ def generate_launch_description():
                         output="screen",
                     ),
                 ]
+            )
+        ]
+        + [
+            RegisterEventHandler(
+                event_handler=OnProcessExit(
+                    on_exit=[
+                        EmitEvent(event=Shutdown()),
+                    ]
+                )
             )
         ]
     )

--- a/src/titan/launch/core.py
+++ b/src/titan/launch/core.py
@@ -9,8 +9,11 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 import launch
-from launch.actions import IncludeLaunchDescription
+from launch.actions import IncludeLaunchDescription, RegisterEventHandler, EmitEvent
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.event import Shutdown
+from launch.event_handlers import OnProcessExit
+
 
 robots = ["asterix"]
 
@@ -30,5 +33,14 @@ def generate_launch_description():
                 }.items(),
             )
             for robot in robots
+        ]
+        + [
+            RegisterEventHandler(
+                event_handler=OnProcessExit(
+                    on_exit=[
+                        EmitEvent(event=Shutdown()),
+                    ]
+                )
+            )
         ]
     )

--- a/src/titan/launch/core.py
+++ b/src/titan/launch/core.py
@@ -11,7 +11,7 @@ from ament_index_python.packages import get_package_share_directory
 import launch
 from launch.actions import IncludeLaunchDescription, RegisterEventHandler, EmitEvent
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.event import Shutdown
+from launch.events import Shutdown
 from launch.event_handlers import OnProcessExit
 
 

--- a/src/titan/launch/interfaces.py
+++ b/src/titan/launch/interfaces.py
@@ -9,9 +9,16 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 import launch
-from launch.actions import GroupAction, IncludeLaunchDescription
+from launch.actions import (
+    GroupAction,
+    IncludeLaunchDescription,
+    RegisterEventHandler,
+    EmitEvent,
+)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
+from launch.event import Shutdown
+from launch.event_handlers import OnProcessExit
 from webots_ros2_core.webots_launcher import WebotsLauncher
 
 
@@ -70,6 +77,15 @@ def generate_launch_description():
                         world="tools/simulation/worlds/cdr2020.wbt",
                     ),
                 ]
+            )
+        ]
+        + [
+            RegisterEventHandler(
+                event_handler=OnProcessExit(
+                    on_exit=[
+                        EmitEvent(event=Shutdown()),
+                    ]
+                )
             )
         ]
     )

--- a/src/titan/launch/interfaces.py
+++ b/src/titan/launch/interfaces.py
@@ -17,7 +17,7 @@ from launch.actions import (
 )
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
-from launch.event import Shutdown
+from launch.events import Shutdown
 from launch.event_handlers import OnProcessExit
 from webots_ros2_core.webots_launcher import WebotsLauncher
 


### PR DESCRIPTION
This doesn't change the behavior of the launch system on the robots. The CI makes use of the `titan` package. 
In titan launch files, it adds an event handler to catch any processes exiting and proceeds to a launcher shutdown, exiting with a non zero code

Fixes #40 