### PR TITLE
Nav 2022

### DIFF
--- a/firmware/ATTiny-Sliders/speedramp.py
+++ b/firmware/ATTiny-Sliders/speedramp.py
@@ -16,7 +16,7 @@ speed_delays = [(1 / x - impulsion_time) for x in speed_frequencies if x != 0]
 
 def find_prescaler(delay):
     for prescaler in range(prescaller_bitsize + 1):
-        clock = cpu_freq / (2 ** prescaler)
+        clock = cpu_freq / (2**prescaler)
         comparator = round(delay * clock)
         if comparator <= 255:
             return prescaler + 1, comparator

--- a/firmware/ATTiny-Stepper/speedramp.py
+++ b/firmware/ATTiny-Stepper/speedramp.py
@@ -16,7 +16,7 @@ speed_delays = [(1 / x - impulsion_time) for x in speed_frequencies if x != 0]
 
 def find_prescaler(delay):
     for prescaler in range(prescaller_bitsize + 1):
-        clock = cpu_freq / (2 ** prescaler)
+        clock = cpu_freq / (2**prescaler)
         comparator = round(delay * clock)
         if comparator <= 255:
             return prescaler + 1, comparator

--- a/src/modules/actuators/actuators/arbotix/arbotix.py
+++ b/src/modules/actuators/actuators/arbotix/arbotix.py
@@ -413,7 +413,7 @@ class ArbotiX:
     ##
     # @return
     def disableWheelMode(self, index, resolution=10):
-        resolution = (2 ** resolution) - 1
+        resolution = (2**resolution) - 1
         self.write(index, ax12.P_CCW_ANGLE_LIMIT_L, [resolution % 256, resolution >> 8])
 
     # Direction definition for setWheelSpeed

--- a/src/modules/robot/param/robot.in.yml
+++ b/src/modules/robot/param/robot.in.yml
@@ -1,12 +1,10 @@
 !Defaults
 use_sim_time: False
-specific_area_coords: "[[0.9, 0.0, 1.5, 0.45],
-[1.5, 0.0, 2.1, 0.45],[0.0, 0.735, 0.55, 0.885],
-[0.0, 0.885, 0.55, 1.035],[0.0, 1.335, 0.55, 1.485],
-[0.0, 1.485, 0.55, 1.635],[2.45, 0.735, 3.0, 0.885],
-[2.45, 0.885, 3.0, 1.035],[2.45, 1.335, 3.0, 1.485],
-[2.45, 1.485, 3.0, 1.635]]"
-exit_area_coords: "[[0.45, 0.45, 0.735, 1.035, 1.335, 1.635, 0.735, 1.035, 1.335, 1.635]]"
+specific_area_coords: "[[0.45, 1.7, 2.55, 2.0],
+[0.0, 1.0, 0.4, 1.6],[2.6, 1.0, 3.0, 1.6],
+[0.0, 0.875, 0.402, 0.625],[2.598, 0.825, 3.0, 0.625]]"
+exit_area_coords: "[[1.7, 0.4, 2.6, 0.402, 2.598]]"
+exit_area_type: "[[0.0, 1.0, 1.0, 1.0, 1.0]]"
 distance_from_walls: 0.25
 ---
 amcl:
@@ -279,3 +277,5 @@ bt_navigator_rclcpp_node:
       distance_from_walls: !Var distance_from_walls
       specific_area_coords: !Var specific_area_coords
       exit_area_coords: !Var exit_area_coords
+      exit_area_type: !Var exit_area_type
+      visualize_zones: true

--- a/src/modules/robot/param/robot.in.yml
+++ b/src/modules/robot/param/robot.in.yml
@@ -2,9 +2,10 @@
 use_sim_time: False
 specific_area_coords: "[[0.45, 1.7, 2.55, 2.0],
 [0.0, 1.0, 0.4, 1.6],[2.6, 1.0, 3.0, 1.6],
-[0.0, 0.875, 0.402, 0.625],[2.598, 0.825, 3.0, 0.625]]"
-exit_area_coords: "[[1.7, 0.4, 2.6, 0.402, 2.598]]"
-exit_area_type: "[[0.0, 1.0, 1.0, 1.0, 1.0]]"
+[0.0, 0.875, 0.402, 0.625],[2.598, 0.825, 3.0, 0.625],
+[0.50, 0.00, 0.0, 0.50], [2.50, 0.00, 3.0, 0.50]]"
+exit_area_coords: "[[1.7, 0.4, 2.6, 0.402, 2.598, 0.25, 0.25]]"
+exit_area_type: "[[0.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0]]"
 distance_from_walls: 0.25
 ---
 amcl:
@@ -53,7 +54,13 @@ bt_navigator:
 
 bt_navigator_rclcpp_node:
   ros__parameters:
-    use_sim_time: !Var use_sim_time
+    use_sim_time: false
+    bt_split_goal:
+      distance_from_walls: !Var distance_from_walls
+      specific_area_coords: !Var specific_area_coords
+      exit_area_coords: !Var exit_area_coords
+      exit_area_type: !Var exit_area_type
+      visualize_zones: true
 
 
 cetautomatix:
@@ -269,13 +276,3 @@ planner_server_rclcpp_node:
 robot_state_publisher:
   ros__parameters:
     use_sim_time: !Var use_sim_time
-
-bt_navigator_rclcpp_node:
-  ros__parameters:
-    use_sim_time: false
-    bt_split_goal:
-      distance_from_walls: !Var distance_from_walls
-      specific_area_coords: !Var specific_area_coords
-      exit_area_coords: !Var exit_area_coords
-      exit_area_type: !Var exit_area_type
-      visualize_zones: true

--- a/src/navigation/bt_custom_plugins/bt_split_goal/include/split_goal_action.hpp
+++ b/src/navigation/bt_custom_plugins/bt_split_goal/include/split_goal_action.hpp
@@ -2,6 +2,8 @@
 #define SPLIT_GOAL_ACTION_HPP_
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
+#include "visualization_msgs/msg/marker.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
 #include "tf2_ros/buffer.h"
 
 #include "nav2_util/robot_utils.hpp"
@@ -61,9 +63,11 @@ private:
 
   double distance_from_walls_;
   std::vector<std::vector<float>> specific_area_coords;
-  std::vector<float> exit_area_coords;
+  std::vector<float> exit_area_coords, exit_area_types;
 
   int get_out_area, get_in_area;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr specific_area_visualization_pub;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr specific_exit_visualization_pub;
 
   float radius_accurate_;
   const float sqrt2by2 = 0.7071068,

--- a/src/navigation/bt_custom_plugins/bt_split_goal/include/split_goal_action.hpp
+++ b/src/navigation/bt_custom_plugins/bt_split_goal/include/split_goal_action.hpp
@@ -71,7 +71,9 @@ private:
 
   float radius_accurate_;
   const float sqrt2by2 = 0.7071068,
-              quaternionDiff = 0.22;
+              quaternionDiff = 0.22,
+              q_z_45 = 0.3826834,
+              q_w_45 = 0.9238795;
 
 };
 

--- a/src/navigation/bt_custom_plugins/bt_split_goal/include/split_goal_action.hpp
+++ b/src/navigation/bt_custom_plugins/bt_split_goal/include/split_goal_action.hpp
@@ -2,6 +2,7 @@
 #define SPLIT_GOAL_ACTION_HPP_
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/point.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 #include "tf2_ros/buffer.h"
@@ -53,6 +54,8 @@ private:
   int intoSpecificZone(geometry_msgs::msg::PoseStamped & pose);
   void setPositionNearWall(geometry_msgs::msg::PoseStamped & pose);
   void nominalSplitter();
+  geometry_msgs::msg::Point findNearestPoint(geometry_msgs::msg::Point p, float x1, float y1, float x2, float y2);
+  bool belowLine(geometry_msgs::msg::Point p, float x1, float y1, float x2, float y2);
 
   geometry_msgs::msg::PoseStamped goal_, get_out_goal_, get_in_goal_, nominal_goal_, current_pose_;
   bool get_out_need_, get_in_need_, nominal_need_;

--- a/src/navigation/bt_custom_plugins/bt_split_goal/src/split_goal_action.cpp
+++ b/src/navigation/bt_custom_plugins/bt_split_goal/src/split_goal_action.cpp
@@ -307,14 +307,18 @@ void SplitGoal::setAutoQuaternions(){
 
 void SplitGoal::setAutoPositions(){
   if (get_out_need_){
-    if (get_out_area != (int)specific_area_coords.size()) get_out_goal_.pose.position.y = exit_area_coords[get_out_area];
-    else {
+    if (get_out_area != (int)specific_area_coords.size()) {
+      if (exit_area_types[get_out_area] == 0.0) get_out_goal_.pose.position.y = exit_area_coords[get_out_area];
+      else get_out_goal_.pose.position.x = exit_area_coords[get_out_area];
+    } else {
       setPositionNearWall(get_out_goal_);
     }
   }
   if (get_in_need_){
-    if (get_in_area != (int)specific_area_coords.size()) nominal_goal_.pose.position.y = exit_area_coords[get_in_area];
-    else {
+    if (get_in_area != (int)specific_area_coords.size()) {
+      if (exit_area_types[get_out_area] == 0.0) nominal_goal_.pose.position.y = exit_area_coords[get_in_area];
+      else nominal_goal_.pose.position.x = exit_area_coords[get_in_area];
+    } else {
       setPositionNearWall(nominal_goal_);
     }
   }

--- a/src/navigation/bt_custom_plugins/bt_split_goal/src/split_goal_action.cpp
+++ b/src/navigation/bt_custom_plugins/bt_split_goal/src/split_goal_action.cpp
@@ -248,21 +248,7 @@ inline BT::NodeStatus SplitGoal::tick()
 }
 
 void SplitGoal::nominalSplitter(){
-  get_in_need_ = true;
-  double dist = sqrt( pow(current_pose_.pose.position.x - goal_.pose.position.x, 2) + pow(current_pose_.pose.position.y - goal_.pose.position.y, 2) );
-  if ( dist < radius_accurate_ ){
-    nominal_need_ = false;
-    get_in_goal_ = goal_;
-  } else {
-    get_in_goal_ = goal_;
-
-    double x_dir = (current_pose_.pose.position.x - goal_.pose.position.x)/dist;
-    double y_dir = (current_pose_.pose.position.y - goal_.pose.position.y)/dist;
-
     nominal_goal_ = goal_;
-    nominal_goal_.pose.position.x = goal_.pose.position.x + radius_accurate_*x_dir;
-    nominal_goal_.pose.position.y = goal_.pose.position.y + radius_accurate_*y_dir;
-  }
 }
 
 void SplitGoal::setOutputPort(){


### PR DESCRIPTION
# Purpose of this PR

This year, some 45° degree obstacle just showed up on the new map. The previous navigation system wasn't able to deal with this kind of angle in specific areas (near obstacles). Here's a little update.

# What has been done ?

The way the navigation works is by splitting the goal depending on the initial position and the goal. 

*Let's take an example:*
The initial position of the robot is `x=0.15, y=1.5, theta=180°`, we give it a navigation goal to `x=1.8, y=0.15, angle=-90°`. 
The behavior tree of the navigation system will determine that the initial state is inside a specific area (which can be found [here](https://github.com/robotique-ecam/cdfr/blob/af853f093544475d87b62b2fa4ee633452818e33/src/modules/robot/param/robot.in.yml#L3)) or near a wall. The system will split this navigation goal into 3 sub navigation goals:
- one to exit the actual specific area,
    - `x=0.3, y=1.5, theta=180°`
- another to enter the desired specific area,
    - `x=1.8, y=0.3, theta=-90°`
- and the last one the final goal.
    - `x=1.8, y=0.15, angle=-90°`

The first sub goal will be achieved by a [slow and accurate controller](https://github.com/robotique-ecam/cdfr/blob/af853f093544475d87b62b2fa4ee633452818e33/src/modules/robot/param/robot.in.yml#L141), the second sub goal will be achieved with a [nominal controller (fast and not accurate)](https://github.com/robotique-ecam/cdfr/blob/af853f093544475d87b62b2fa4ee633452818e33/src/modules/robot/param/robot.in.yml#L97), and the last goal will be achieved with the same first controller.

This update allows the navigation system to deal with 45° angle specific area obstacles. You can know visualize those specific areas with their entrance and exit zones directly in rviz by activating [`visualize_zones`](https://github.com/robotique-ecam/cdfr/blob/af853f093544475d87b62b2fa4ee633452818e33/src/modules/robot/param/robot.in.yml#L63) in the yaml configuration of the navigation behavior tree plugin `bt_split_goal` (on the topic `/asterix/nav_specific_exit` or obelix depending on which robot you're running).
![visualize_area](https://user-images.githubusercontent.com/56687350/153092824-b1f7989d-c290-49dc-8978-36c818ff0e82.jpeg)


# Extra
You can force the utilization of the accurate controller by setting `z=2.0` when sending a movement request to the navigation system. It will completely skip the splitting of goal. Same thing for nominal controller with `z=1.0`. Automatic mode with `z=0.0`.
[The behavior tree](https://github.com/robotique-ecam/cdfr/blob/06b941ecb3135d146926a848f645ae486659d451/src/navigation/bt_custom_plugins/nav2_custom_bt_picture/nav2_bt_custom.png) (might also need an update, names of controllers have changed).